### PR TITLE
Update to v0.13.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v1
+        with:
+          depth: 1
+          submodules: false
+      - name: Build docker image
+        run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.10-alpine
 
-ENV GHR_VERSION="0.10.2"
+ENV GHR_VERSION="0.13.0"
 
 RUN apk add --update --no-cache git \
     && apk add --no-cache --virtual build-deps curl \


### PR DESCRIPTION
This updates ghr to the most recent release.

Also includes a small GitHub workflow to check whether a docker build produces any result.